### PR TITLE
Fixed EVA manipulation of Printers/Cargo containers

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/largeStorageContainer.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/largeStorageContainer.cfg
@@ -36,15 +36,15 @@
 
 	MODULE
 	{
-		name = ModuleInventoryPart
-		InventorySlots = 24
-		packedVolumeLimit = 16000
+		name = ModuleCargoPart
+		packedVolume = -1
 	}
 
 	MODULE
 	{
-		name = ModuleCargoPart
-		packedVolume = -1
+		name = ModuleInventoryPart
+		InventorySlots = 24
+		packedVolumeLimit = 16000
 	}
 
 	MODULE

--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/mediumStorageContainer.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/mediumStorageContainer.cfg
@@ -36,15 +36,15 @@
 
 	MODULE
 	{
-		name = ModuleInventoryPart
-		InventorySlots = 24
-		packedVolumeLimit = 8000
+		name = ModuleCargoPart
+		packedVolume = -1
 	}
 
 	MODULE
 	{
-		name = ModuleCargoPart
-		packedVolume = -1
+		name = ModuleInventoryPart
+		InventorySlots = 24
+		packedVolumeLimit = 8000
 	}
 
 	MODULE

--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/smallStorageContainer.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Cargo/smallStorageContainer.cfg
@@ -36,15 +36,15 @@
 
 	MODULE
 	{
-		name = ModuleInventoryPart
-		InventorySlots = 24
-		packedVolumeLimit = 4000
+		name = ModuleCargoPart
+		packedVolume = -1
 	}
 
 	MODULE
 	{
-		name = ModuleCargoPart
-		packedVolume = -1
+		name = ModuleInventoryPart
+		InventorySlots = 24
+		packedVolumeLimit = 4000
 	}
 
 	MODULE

--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Utility/PrintShops/Size2PrintShop.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Utility/PrintShops/Size2PrintShop.cfg
@@ -181,15 +181,15 @@
 
 	MODULE
 	{
-		name = ModuleInventoryPart
-		InventorySlots = 6
-		packedVolumeLimit = 11000
+		name = ModuleCargoPart
+		packedVolume = -1
 	}
 
 	MODULE
 	{
-		name = ModuleCargoPart
-		packedVolume = -1
+		name = ModuleInventoryPart
+		InventorySlots = 6
+		packedVolumeLimit = 11000
 	}
 
 	MODULE

--- a/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Utility/PrintShops/Size2PrintShopSmall.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/Sandcastle/Parts/Utility/PrintShops/Size2PrintShopSmall.cfg
@@ -177,15 +177,15 @@
 
 	MODULE
 	{
-		name = ModuleInventoryPart
-		InventorySlots = 3
-		packedVolumeLimit = 200
+		name = ModuleCargoPart
+		packedVolume = -1
 	}
 
 	MODULE
 	{
-		name = ModuleCargoPart
-		packedVolume = -1
+		name = ModuleInventoryPart
+		InventorySlots = 3
+		packedVolumeLimit = 200
 	}
 
 	MODULE


### PR DESCRIPTION
For EVA manipulatable parts with inventory slots, ModuleCargoPart must come before ModuleInventoryPart